### PR TITLE
Non spdx licenses

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -13,5 +13,11 @@
   "MPL-2.0",
   "ODC-By-1.0",
   "OGL-UK-3.0",
-  "Unlicense"
+  "Unlicense",
+  "LGPL",
+  "Apache 2.0",
+  "GPL",
+  "Expat license",
+  "Apache",
+  "Artistic License"
 ]


### PR DESCRIPTION
python is a bit loose on license definitions so adding these strings to our allowed licenses list