### PR TITLE
disable eslint no-unused-vars repalce with typescript rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ module.exports = {
     }],
     "semi": ["error", "always"],
     "no-dupe-keys": "error",
-    "quotes": ["warn", "single", { "avoidEscape": true }]
+    "quotes": ["warn", "single", { "avoidEscape": true }],
+    "no-unused-vars": 0,
+    "@typescript-eslint/no-unused-vars": 2
   },
   settings: {
     react: {


### PR DESCRIPTION
turn off eslint check to prevent false positives in typescript interfaces and use specific typescript rule to check for unused vars